### PR TITLE
Add postgres superuser password and clarify README

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 POSTGRES_USER=dbuser
 POSTGRES_PASSWORD=dbpassword1234
+POSTGRES_ADMIN_PASSWORD=new_secure_supersuer_postgres_password

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ vim .env
 //.env
 POSTGRES_USER=new_postgres_username
 POSTGRES_PASSWORD=new_secure_postgres_password
+POSTGRES_ADMIN_PASSWORD=new_secure_supersuer_postgres_password
 ```
 
 Seed postgres database
@@ -30,7 +31,7 @@ Start everything
 docker-compose up -d
 ```
 
-Guacamole is now listening on port 8080
+Guacamole is now listening on port 8080, such as `http://[HOST IP]:8080/guacamole`.
 
 default username: guacadmin
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - dbdata:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-guacdb}
-      POSTGRES_PASSWORD: 
+      POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD:-guacdb}
     depends_on:
       - init-guacamole-db
 
@@ -33,7 +33,7 @@ services:
       POSTGRES_HOSTNAME: postgres
       POSTGRES_DATABASE: ${POSTGRES_USER:-guacdb}
       POSTGRES_USER: ${POSTGRES_USER:-guacdb}
-      POSTGRES_PASSWORD:
+      POSTGRES_PASSWORD: ${POSTGRES_ADMIN_PASSWORD:-guacdb}
     depends_on:
       - postgres
       - guacd


### PR DESCRIPTION
README was missing full URL hint (i.e. existing instructions just say `listening on port 8080` but no indication to go to `:8080/guacamole`.

Additionally, there are no instructions in the README that suggest that the postgres supersuser password need to be set. Added this to the .env so that it's automated with the other username and password.